### PR TITLE
FEAT: 이메일, 비밀번호 동적 유효성 검사

### DIFF
--- a/src/components/auth/AuthChangePwBox.tsx
+++ b/src/components/auth/AuthChangePwBox.tsx
@@ -13,6 +13,7 @@ export default function AuthChangePwBox() {
         재설정할 비밀번호를 <br /> 입력해주세요.
       </div>
       <AuthChangePwInput />
+
       <Button contents={'변경하기'} />
     </PwBox>
   );

--- a/src/components/auth/AuthCheckPw.tsx
+++ b/src/components/auth/AuthCheckPw.tsx
@@ -2,5 +2,9 @@ import { IAuthCheckPw } from '@/types/IAuth';
 
 // 비밀번호 확인 체크 컴포넌트
 export default function AuthCheckPw({ pwd, checkedPwd }: IAuthCheckPw) {
-  return <div>{pwd === checkedPwd ? 'O' : 'X'}</div>;
+  return (
+    <div>
+      {pwd === checkedPwd && pwd.length > 8 ? '비밀번호가 일치합니다.' : 'X'}
+    </div>
+  );
 }

--- a/src/components/auth/sign-up/AuthEmailCheck.tsx
+++ b/src/components/auth/sign-up/AuthEmailCheck.tsx
@@ -1,0 +1,14 @@
+import { IRegexCheck } from '@/types/ISignUp';
+
+export default function AuthEmailCheck({ valid }: IRegexCheck) {
+  const validMessage = () => {
+    if (!valid) {
+      return (
+        <div className="text-secondary text-xs ml-1">
+          이메일 주소를 정확히 입력해주세요.
+        </div>
+      );
+    }
+  };
+  return <div>{validMessage()}</div>;
+}

--- a/src/components/auth/sign-up/AuthPwCheck.tsx
+++ b/src/components/auth/sign-up/AuthPwCheck.tsx
@@ -1,0 +1,14 @@
+import { IRegexCheck } from '@/types/ISignUp';
+
+export default function AuthPwCheck({ valid }: IRegexCheck) {
+  const validMessage = () => {
+    if (!valid) {
+      return (
+        <div className="text-secondary text-xs ml-1">
+          영문, 숫자를 조합하여 입력해주세요. (8-16자)
+        </div>
+      );
+    }
+  };
+  return <div>{validMessage()}</div>;
+}

--- a/src/components/auth/sign-up/AuthSignUpInput.tsx
+++ b/src/components/auth/sign-up/AuthSignUpInput.tsx
@@ -1,39 +1,24 @@
-import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+import AuthPwCheck from './AuthPwCheck';
+import AuthEmailCheck from './AuthEmailCheck';
+import { signUpState } from '@/recoil/signUp';
 import Input from '@/components/common/Input';
-import { IAuthSignUpInput } from '@/types/IAuth';
 import Button from '@/components/common/Button';
+import { IAuthSignUpInput } from '@/types/IAuth';
 import AuthCheckPw from '@/components/auth/AuthCheckPw';
+import { rEmail, rPassword } from '@/constants/constants';
 
-export default function AuthSignUpInput({
-  info,
-  button,
-  placeholder,
-  enLabel,
-  type
-}: IAuthSignUpInput) {
-  const [signupInput, setSignupInput] = useState({
-    profileUrl: '',
-    position: '',
-    name: '',
-    email: '',
-    password: '',
-    checkedPwd: '',
-    phone: '',
-    hireDate: ''
-  });
+export default function AuthSignUpInput({ ...props }: IAuthSignUpInput) {
+  // 회원가입 정보 atom state 구독
+  const [signUpInfo, setSignUpInfo] = useRecoilState(signUpState);
 
-  const { password, checkedPwd } = signupInput;
-
-  // console.log(`password: ${password}`);
-  // console.log(`checked : ${checkedPwd}`);
-
-  // input 입력 값 처리
+  // input 입력 값 atom state 업데이트
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
-    setSignupInput({
-      ...signupInput,
+    setSignUpInfo(prevInformation => ({
+      ...prevInformation,
       [name]: value
-    });
+    }));
   };
 
   // 이메일 중복 체크 (업데이트 전)
@@ -41,35 +26,90 @@ export default function AuthSignUpInput({
     alert('사용 가능한 이메일입니다.');
   };
 
-  // 조건부 버튼 렌더링
+  // 버튼 & 비밀번호 확인 조건부 렌더링
   const renderButton = () => {
-    if (button) {
-      if (button === '중복확인')
+    // button props가 있을 때
+    if (props.button) {
+      // 중복확인 버튼일 경우
+      if (props.button === '중복확인')
         return (
-          <Button contents={button} onClick={onDuplicateClick} secondary />
+          <Button
+            contents={props.button}
+            onClick={onDuplicateClick}
+            secondary
+          />
         );
+      // 업로드 버튼일 경우
       else {
         return (
-          <Button contents={button} onClick={onDuplicateClick} secondary />
+          <Button
+            contents={props.button}
+            onClick={onDuplicateClick}
+            secondary
+          />
         );
       }
-    } else if (info === '비밀번호 확인') {
-      return <AuthCheckPw pwd={password} checkedPwd={checkedPwd} />;
+      // 비밀번호 확인일 경우
+    } else if (props.label === '비밀번호 확인') {
+      return (
+        <AuthCheckPw
+          pwd={signUpInfo.password}
+          checkedPwd={signUpInfo.checkedPwd}
+        />
+      );
     } else return;
   };
 
+  // 이메일 형식 유효성 체크
+  const emailCheck = () => {
+    if (signUpInfo.email.trim() === '') {
+      return true;
+    }
+
+    return rEmail.test(signUpInfo.email);
+  };
+
+  // 비밀번호 형식 유효성 체크
+  const passwordCheck = () => {
+    if (signUpInfo.password.trim() === '') {
+      return true;
+    }
+
+    return rEmail.test(signUpInfo.password);
+  };
+
+  const renderValid = () => {
+    if (props.name === 'email') return emailCheck();
+    else if (props.name === 'password') return passwordCheck();
+    else return true;
+  };
+
+  // 유효성에 따른 조건부 렌더링
+  const renderRegex = () => {
+    if (props.label === '이메일') {
+      return <AuthEmailCheck valid={emailCheck()} />;
+    }
+    if (props.label === '비밀번호') {
+      return <AuthPwCheck valid={passwordCheck()} />;
+    }
+  };
+
   return (
-    <div className="flex mb-4">
-      <Input
-        label={`${info}`}
-        name={enLabel}
-        onChange={handleChange}
-        placeholder={placeholder}
-        type={type}
-      />
-      <div className="flex sm:min-w-[5rem] min-w-[4rem] items-end justify-cente ml-4">
-        {renderButton()}
+    <div className="sm:mb-4 mb-2">
+      <div className="flex">
+        <Input
+          label={`${props.label}`}
+          name={props.name}
+          onChange={handleChange}
+          placeholder={props.placeholder}
+          type={props.type}
+          valid={renderValid()}
+        />
+        <div className="flex sm:min-w-[5rem] min-w-[4rem] items-end justify-cente ml-4">
+          {renderButton()}
+        </div>
       </div>
+      {renderRegex()}
     </div>
   );
 }

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,4 +1,4 @@
-interface InputProps {
+interface IInputProps {
   placeholder?: string;
   value?: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -6,33 +6,28 @@ interface InputProps {
   type?: string;
   label?: string;
   name: string;
+  valid?: boolean;
 }
 
-export default function Input({
-  placeholder,
-  value,
-  onChange,
-  onKeyUp,
-  type,
-  label,
-  name
-}: InputProps) {
+export default function Input({ ...props }: IInputProps) {
   return (
     <div className="w-full">
       <label
         className="text-xs sm:text-base min-w-[5rem] sm:min-w-[10rem] flex"
-        htmlFor={label}>
-        {label}
+        htmlFor={props.label}>
+        {props.label}
       </label>
       <input
-        name={name}
-        id={label}
-        className="mt-1 h-10 w-full rounded-lg border-2 border-subTextAndBorder px-3 py-2 text-xs outline-none transition focus:border-primary sm:h-12 sm:text-base"
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        onKeyUp={onKeyUp}
-        type={type}
+        name={props.name}
+        id={props.label}
+        className={`${
+          props.valid ? 'focus:border-primary' : 'focus:border-secondary'
+        } mt-1 h-10 w-full rounded-lg border-2 border-subTextAndBorder px-3 py-2 text-xs outline-none transition sm:h-12 sm:text-base`}
+        placeholder={props.placeholder}
+        value={props.value}
+        onChange={props.onChange}
+        onKeyUp={props.onKeyUp}
+        type={props.type}
       />
     </div>
   );

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,7 +1,7 @@
 import { ISignUpItem } from '@/types/IAuth';
 
 // 이메일 유효성 정규식
-export const rEmail = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+export const rEmail = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 // 영문+숫자로 이루어진 8자리 이상, 16자리 이하 유효성 정규식
 export const rPassword = /^(?=.[A-Za-z])(?=.\d).{8,16}$/;

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,52 +1,58 @@
 import { ISignUpItem } from '@/types/IAuth';
 
+// 이메일 유효성 정규식
+export const rEmail = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+
+// 영문+숫자로 이루어진 8자리 이상, 16자리 이하 유효성 정규식
+export const rPassword = /^(?=.[A-Za-z])(?=.\d).{8,16}$/;
+
 export const SIGNUP_INPUT_INFO: ISignUpItem[] = [
   {
     label: '부서명',
-    enLabel: 'position',
+    name: 'position',
     placeholder: '부서명을 선택하세요.',
     type: 'text'
   },
   {
     label: '이름',
-    enLabel: 'name',
+    name: 'name',
     placeholder: '이름을 입력해주세요',
     type: 'text'
   },
   {
     label: '이메일',
-    enLabel: 'email',
+    name: 'email',
     button: '중복확인',
     placeholder: '예: dangyeon@dangyeon.com',
     type: 'email'
   },
   {
     label: '비밀번호',
-    enLabel: 'password',
+    name: 'password',
     placeholder: '영문+숫자로 이루어진 8자리 이상, 16자리 이하',
     type: 'password'
   },
   {
     label: '비밀번호 확인',
-    enLabel: 'checkedPwd',
+    name: 'checkedPwd',
     placeholder: '비밀번호를 한번 더 입력해주세요.',
     type: 'password'
   },
   {
     label: '휴대폰 번호',
-    enLabel: 'phone',
+    name: 'phone',
     placeholder: '010-1234-5678',
     type: 'tel'
   },
   {
     label: '입사일',
-    enLabel: 'hireDate',
+    name: 'hireDate',
     placeholder: '날짜를 선택해주세요.',
     type: 'date'
   },
   {
     label: '프로필 사진',
-    enLabel: 'profileUrl',
+    name: 'profileUrl',
     button: '업로드',
     placeholder: '선택된 이미지 없음.',
     type: 'file'

--- a/src/pages/sign-up.tsx
+++ b/src/pages/sign-up.tsx
@@ -1,3 +1,4 @@
+import { RecoilRoot } from 'recoil';
 import Button from '@/components/common/Button';
 import { SIGNUP_INPUT_INFO } from '@/constants/constants';
 import AuthSignUpInput from '@/components/auth/sign-up/AuthSignUpInput';
@@ -5,19 +6,21 @@ import AuthSignUpTitle from '@/components/auth/sign-up/AuthSignUpTitle';
 
 export default function SignUp() {
   return (
-    <div className="mx-auto sm:w-[500px] sm:my-[90px]">
-      <AuthSignUpTitle />
-      {SIGNUP_INPUT_INFO.map(value => (
-        <AuthSignUpInput
-          key={value.label}
-          info={value.label}
-          button={value.button}
-          placeholder={value.placeholder}
-          enLabel={value.enLabel}
-          type={value.type}
-        />
-      ))}
-      <Button contents={'회원가입'} />
-    </div>
+    <RecoilRoot>
+      <div className="mx-auto sm:w-[500px] sm:my-[90px]">
+        <AuthSignUpTitle />
+        {SIGNUP_INPUT_INFO.map(value => (
+          <AuthSignUpInput
+            key={value.label}
+            label={value.label}
+            button={value.button}
+            placeholder={value.placeholder}
+            name={value.name}
+            type={value.type}
+          />
+        ))}
+        <Button contents={'회원가입'} />
+      </div>
+    </RecoilRoot>
   );
 }

--- a/src/recoil/signUp.ts
+++ b/src/recoil/signUp.ts
@@ -1,0 +1,16 @@
+import { atom } from 'recoil';
+import { ISignUp } from '@/types/ISignUp';
+
+export const signUpState = atom<ISignUp>({
+  key: 'signUpState',
+  default: {
+    profileUrl: '',
+    position: '',
+    name: '',
+    email: '',
+    password: '',
+    checkedPwd: '',
+    phone: '',
+    hireDate: ''
+  }
+});

--- a/src/types/IAuth.ts
+++ b/src/types/IAuth.ts
@@ -1,6 +1,6 @@
 export interface IAuthSignUpInput {
-  info: string;
-  enLabel: string;
+  label: string;
+  name: string;
   button?: string;
   placeholder?: string;
   type: string;
@@ -8,13 +8,13 @@ export interface IAuthSignUpInput {
 
 export interface ISignUpItem {
   label: string;
-  enLabel: string;
+  name: string;
   button?: string;
   placeholder?: string;
   type: string;
 }
 
 export interface IAuthCheckPw {
-  pwd?: string;
-  checkedPwd?: string;
+  pwd: string;
+  checkedPwd: string;
 }

--- a/src/types/ISignUp.ts
+++ b/src/types/ISignUp.ts
@@ -1,0 +1,14 @@
+export interface ISignUp {
+  profileUrl: string;
+  position: string;
+  name: string;
+  email: string;
+  password: string;
+  checkedPwd: string;
+  phone: string;
+  hireDate: string;
+}
+
+export interface IRegexCheck {
+  valid?: boolean;
+}


### PR DESCRIPTION
## ✨ 기능명
<img width="582" alt="image" src="https://github.com/1017yu/this-is-money/assets/83483378/46eeed89-ac3b-42cc-bc88-e56ee010d7bd">

<img width="582" alt="image" src="https://github.com/1017yu/this-is-money/assets/83483378/812e5235-b2bc-4c43-900e-9b4ff223ec63">

<img width="582" alt="image" src="https://github.com/1017yu/this-is-money/assets/83483378/d6ae1eab-e180-4014-9158-74f39d71bde2">

### 📝 작업 내용
이메일과 비밀번호를 사전에 지정해놓은 유효식에 따라 동적으로 유효성 검사를 하도록 하였습니다.

rEmail = ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
- 이메일의 로컬파트에 영문과 숫자, ._%+- 를 포함할 수 있습니다.

rPassword = ^(?=.[A-Za-z])(?=.\d).{8,16}$
- 영문+숫자로 이루어진 8자리 이상, 16자리 이하로 이루어져야합니다.


### ⚾️ 관련 이슈
closed #35


### 🛠️ 궁금한 사항 또는 공유할 사항
- [ ] 비밀번호 유효성 검사 다시 확인중입니다.