### PR TITLE
FEAT: 비밀번호 찾기를 위한 이메일 전송 API 세팅

### DIFF
--- a/src/api/auth/findPw.ts
+++ b/src/api/auth/findPw.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { clientInstance } from '../axios';
+import { ISignInRequestBody } from '@/types/ISignIn';
+
+// * [POST] 비밀번호 변경을 위한 이메일 전송
+export async function requestFindPw(findPwData: ISignInRequestBody) {
+  try {
+    const response = await axios.post(
+      `${clientInstance.defaults.baseURL}/api/auth/users/password/find`,
+      findPwData
+    );
+    return response;
+  } catch (error) {
+    console.error('INVALID_EMAIL', error);
+    throw error;
+  }
+}

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,17 +2,11 @@ import axios, { AxiosError } from 'axios';
 
 const apiIP = process.env.NEXT_PUBLIC_API_IP;
 const clientPort = process.env.NEXT_PUBLIC_API_CLIENT_PORT;
-const adminPort = process.env.NEXT_PUBLIC_API_ADMIN_PORT;
 
 const clientUrl = `http://${apiIP}:${clientPort}`;
-const adminUrl = `http://${apiIP}:${adminPort}`;
 
 export const clientInstance = axios.create({
   baseURL: `${clientUrl}`
-});
-
-export const adminInstance = axios.create({
-  baseURL: `${adminUrl}`
 });
 
 clientInstance.interceptors.request.use(
@@ -25,24 +19,6 @@ clientInstance.interceptors.request.use(
 );
 
 clientInstance.interceptors.response.use(
-  function (response) {
-    return response;
-  },
-  function (error: AxiosError) {
-    return Promise.reject(error.response?.data);
-  }
-);
-
-adminInstance.interceptors.request.use(
-  function (config) {
-    return config;
-  },
-  function (error: AxiosError) {
-    return Promise.reject(error);
-  }
-);
-
-adminInstance.interceptors.response.use(
   function (response) {
     return response;
   },

--- a/src/components/auth/AuthFindPwInput.tsx
+++ b/src/components/auth/AuthFindPwInput.tsx
@@ -2,11 +2,10 @@ import { useState } from 'react';
 import Input from '@/components/common/Input';
 import { rEmail } from '@/constants/constants';
 import Button from '@/components/common/Button';
-
+import { requestFindPw } from '@/api/auth/findPw';
 
 export default function AuthFindPwInput() {
   const [email, setEmail] = useState('');
-
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event?.target.value);
@@ -15,6 +14,19 @@ export default function AuthFindPwInput() {
   // 이메일 형식 유효성 체크
   const emailCheck = () => {
     return rEmail.test(email);
+  };
+
+  const handleFindPw = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    try {
+      const response = await requestFindPw({
+        email: email
+      });
+      if (response.status === 200) {
+        const userData = response.data;
+      }
+    } catch (error) {}
   };
 
   return (
@@ -28,7 +40,9 @@ export default function AuthFindPwInput() {
           valid={emailCheck()}
         />
       </div>
-      <Button contents={'이메일 전송'} disabled={!emailCheck()} />
+      <form onSubmit={handleFindPw}>
+        <Button contents={'이메일 전송'} disabled={!emailCheck()} submit />
+      </form>
     </>
   );
 }

--- a/src/components/auth/sign-in/AuthSignInBox.tsx
+++ b/src/components/auth/sign-in/AuthSignInBox.tsx
@@ -4,11 +4,12 @@ import { signInState } from '@/recoil/signIn';
 import PwBox from '@/components/common/PwBox';
 import Button from '@/components/common/Button';
 import { requestSignIn } from '@/api/auth/signIn';
-import { ILocalUser, ISignInUser } from '@/types/ISignIn';
+import { ISignInUser } from '@/types/ISignIn';
 import AuthSignInInput from '@/components/auth/sign-in/AuthSignInInput';
 
 export default function AuthSignInBox() {
   const signInInfo = useRecoilValue(signInState);
+
   const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -19,7 +20,7 @@ export default function AuthSignInBox() {
       });
       if (response.status === 200) {
         const userData: ISignInUser = response.data;
-        const localUserData: ILocalUser = {
+        const localUserData: ISignInUser = {
           accessToken: userData.accessToken,
           refreshToken: userData.refreshToken,
           accessTokenExpireDate: userData.accessTokenExpireDate

--- a/src/types/ISignin.ts
+++ b/src/types/ISignin.ts
@@ -8,5 +8,3 @@ export interface ISignInUser {
   refreshToken: string;
   accessTokenExpireDate: number;
 }
-
-export type ILocalUser = Omit<ISignInUser, 'userId'>;


### PR DESCRIPTION
## ✨ 기능명
비밀번호 찾기를 위한 이메일 전송 API 세팅

### 📝 작업 내용
비밀번호 찾기를 위한 이메일 전송 API 세팅,
관리자 서버 미 가동에 따른 axios 수정

### ⚾️ 관련 이슈


### 🛠️ 궁금한 사항 또는 공유할 사항

